### PR TITLE
Wipe out irc client from support page

### DIFF
--- a/website_example/config.js
+++ b/website_example/config.js
@@ -4,7 +4,7 @@ var coinUnits = 1000000000000;
 
 var poolHost = "cryppit.com";
 
-var irc = "irc.freenode.net/#monero";
+var irc = "irc.freenode.net/#monero-pools";
 
 var email = "support@cryppit.com";
 


### PR DESCRIPTION
Many pool ops won't spend a minute to customise support page, there are a lot of people complaining of their payouts in #monero channel in all languages. Please remove irc client from support page and force pools to provide qualified support.
