### PR TITLE
Fail on detect duplicate share

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -499,7 +499,7 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                 sendReply('Invalid job id');
                 return;
             }
-
+            params.nonce = params.nonce.replace(/\s+/, "") ;
             if (job.submissions.indexOf(params.nonce) !== -1){
                 sendReply('Duplicate share');
                 return;


### PR DESCRIPTION
 "4500450" is not same  "45004500      "
Validshare use copy ( not use space on copy )
