### PR TITLE
Fix nethash, miner hash and estimation

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -164,8 +164,8 @@ function getPublicPorts(ports){
 function getReadableHashRateString(hashrate){
     var i = 0;
     var byteUnits = [' H', ' KH', ' MH', ' GH', ' TH', ' PH' ];
-    while (hashrate > 1024){
-        hashrate = hashrate / 1024;
+    while (hashrate > 1000){
+        hashrate = hashrate / 1000;
         i++;
     }
     return hashrate.toFixed(2) + byteUnits[i];

--- a/website_example/pages/home.html
+++ b/website_example/pages/home.html
@@ -267,8 +267,8 @@
     function getReadableHashRateString(hashrate){
         var i = 0;
         var byteUnits = [' H', ' KH', ' MH', ' GH', ' TH', ' PH' ];
-        while (hashrate > 1024){
-            hashrate = hashrate / 1024;
+        while (hashrate > 1000){
+            hashrate = hashrate / 1000;
             i++;
         }
         return hashrate.toFixed(2) + byteUnits[i];
@@ -324,7 +324,7 @@
 
     function calcEstimateProfit(){
         try {
-            var rateUnit = Math.pow(1024,parseInt($('#calcHashUnit').data('mul')));
+            var rateUnit = Math.pow(1000,parseInt($('#calcHashUnit').data('mul')));
             var inp2 = parseFloat($('#calcHashRate').val()) * rateUnit;
             var resl = 16 / ((lastStats.network.difficulty / inp2) / 86400);
             if (!isNaN(resl)) {


### PR DESCRIPTION
Should divide by 1000, not 1024. Don't think it's binary prefixes, at least keep things consistent with daemon **diff** output. Issue: https://github.com/zone117x/node-cryptonote-pool/issues/81