### PR TITLE
Fix luck calculation via an approximation

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -67,6 +67,7 @@
         "slushMining": {
             "enabled": true,
             "weight": 120,
+            "blockTime": 60,
             "lastBlockCheckRate": 1
         }
     },

--- a/lib/api.js
+++ b/lib/api.js
@@ -137,7 +137,10 @@ function collectStats(){
                 doDonations: doDonations,
                 version: version,
                 minPaymentThreshold: config.payments.minPayment,
-                denominationUnit: config.payments.denomination
+                denominationUnit: config.payments.denomination,
+                blockTime: config.poolServer.slushMining.blockTime,
+                slushMiningEnabled: config.poolServer.slushMining.enabled,
+                weight: config.poolServer.slushMining.weight
             });
         }
     }, function(error, results){

--- a/website_example/pages/pool_blocks.html
+++ b/website_example/pages/pool_blocks.html
@@ -119,12 +119,29 @@
     function getBlockRowElement(block, jsonString){
 
         function formatLuck(difficulty, shares){
-            if (difficulty > shares){
-                var percent = 100 - Math.round(shares / difficulty * 100);
+            //accurateShares is only an approximation to reverse the calcualtions done in pool.js, because the shares with their respective are not recorded in redis
+            //Approximation assumes equal pool hashrate for the whole round
+            //Could potentially be replaced by storing the sum of all job.difficulty in the redis db. 
+            if (lastStats.config.slushMiningEnabled) {
+                var accurateShares = shares / (1/lastStats.config.blockTime * (             //This uses integral calculus to calculate the "area below the graph". We need 1/blockTime for the average
+                    lastStats.config.weight - lastStats.config.weight *                     //This is the integrated function of the original function sligthly modified.
+                        Math.pow(                                                           //Instead of (scoreTime - dateNowSeconds) it used (x-blockTime)
+                            Math.E,                                                         //This is possible because we calculated it in the intervall of 0 to blocktime
+                            ((lastStats.config.blockTime * (-1)) / lastStats.config.weight)
+                         )
+                    )
+                );
+            }
+            else {
+                var accurateShares = shares;
+            }
+
+            if (difficulty > accurateShares){
+                var percent = 100 - Math.round(accurateShares / difficulty * 100);
                 return '<span class="luckGood">' + percent + '%</span>';
             }
             else{
-                var percent = (100 - Math.round(difficulty / shares * 100)) * -1;
+                var percent = (100 - Math.round(difficulty / accurateShares * 100)) * -1;
                 return '<span class="luckBad">' + percent + '%</span>';
             }
         }


### PR DESCRIPTION
Because I want to avoid changing the redis db, but we also can't reverse calculate slush's score valuation, we use an approximation, that should come close enough
Approximation function assumes an equal hashrate for the whole round