### PR TITLE
Update to move to Snipa22's updated node-cryptonote-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "dateformat": "1.0.12",
         "base58-native": "0.1.4",
         "multi-hashing": "git://github.com/zone117x/node-multi-hashing.git",
-        "cryptonote-util": "git://github.com/zone117x/node-cryptonote-util.git"
+        "cryptonote-util": "git://github.com/Snipa22/node-cryptonote-util#xmr-Nan-2.0"
     },
     "engines": {
         "node": ">=0.10"


### PR DESCRIPTION
The current node-cryptonote-util returns a buffer object, rather than the expected address type integer.  This code fixes that.