### PR TITLE
Remove round in the same transaction as getting it

### DIFF
--- a/lib/blockUnlocker.js
+++ b/lib/blockUnlocker.js
@@ -97,10 +97,11 @@ function runInterval(){
         function(blocks, callback){
 
 
-            var redisCommands = blocks.map(function(block){
-                return ['hgetall', config.coin + ':shares:round' + block.height];
+            var redisCommands = [];
+            blocks.forEach(function(block) {
+                redisCommands.push(['hgetall', config.coin + ':shares:round' + block.height]);
+                redisCommands.push(['del', config.coin + ':shares:round' + block.height]);
             });
-
 
             redisClient.multi(redisCommands).exec(function(error, replies){
                 if (error){
@@ -108,9 +109,9 @@ function runInterval(){
                     callback(true);
                     return;
                 }
-                for (var i = 0; i < replies.length; i++){
+                for (var i = 0; i < replies.length; i = i + 2){
                     var workerShares = replies[i];
-                    blocks[i].workerShares = workerShares;
+                    blocks[i / 2 >> 0].workerShares = workerShares;
                 }
                 callback(null, blocks);
             });
@@ -122,8 +123,6 @@ function runInterval(){
 
             blocks.forEach(function(block){
                 if (!block.orphaned) return;
-
-                orphanCommands.push(['del', config.coin + ':shares:round' + block.height]);
 
                 orphanCommands.push(['zrem', config.coin + ':blocks:candidates', block.serialized]);
                 orphanCommands.push(['zadd', config.coin + ':blocks:matured', block.height, [
@@ -166,7 +165,6 @@ function runInterval(){
                 if (block.orphaned) return;
                 totalBlocksUnlocked++;
 
-                unlockedBlocksCommands.push(['del', config.coin + ':shares:round' + block.height]);
                 unlockedBlocksCommands.push(['zrem', config.coin + ':blocks:candidates', block.serialized]);
                 unlockedBlocksCommands.push(['zadd', config.coin + ':blocks:matured', block.height, [
                     block.hash,


### PR DESCRIPTION
It avoid race condition when multiple blockUnlockers instances are running, and they add the reward multiple times.

Before this, two instances might both have taken the same round information, remove it and adds the same reward twice, which ruins the statistic.