### PR TITLE
Added support for miners using Proxy V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Comes with lightweight example front-end script which uses the pool's AJAX API.
 * https://moneropool.com
 * http://monero.crypto-pool.fr
 * https://minexmr.com
+* https://moneropool.us
 
 
 Usage

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -50,6 +50,7 @@ var shareTrustMinFloat = shareTrustEnabled ? config.poolServer.shareTrust.min / 
 
 
 var banningEnabled = config.poolServer.banning && config.poolServer.banning.enabled;
+var client_ip = {};
 
 
 setInterval(function(){
@@ -97,7 +98,7 @@ process.on('message', function(message) {
 
 
 function IsBannedIp(ip){
-    if (!banningEnabled || !bannedIPs[ip]) return false;
+    if (!banningEnabled || !bannedIPs[ip] || ip == "127.0.0.1") return false;
 
     var bannedTime = bannedIPs[ip];
     var bannedTimeAgo = Date.now() - bannedTime;
@@ -616,7 +617,8 @@ var httpResponse = ' 200 OK\nContent-Type: text/plain\nContent-Length: 20\n\nmin
 
 function startPoolServerTcp(callback){
     async.each(config.poolServer.ports, function(portData, cback){
-        var handleMessage = function(socket, jsonData, pushMessage){
+        var handleMessage = function(socket, jsonData, pushMessage, c_ip){
+            c_ip = c_ip || socket.remoteAddress;
             if (!jsonData.id) {
                 log('warn', logSystem, 'Miner RPC request missing RPC id');
                 return;
@@ -641,7 +643,7 @@ function startPoolServerTcp(callback){
                 socket.write(sendData);
             };
 
-            handleMinerMethod(jsonData.method, jsonData.params, socket.remoteAddress, portData, sendReply, pushMessage);
+            handleMinerMethod(jsonData.method, jsonData.params, c_ip, portData, sendReply, pushMessage);
         };
 
         net.createServer(function(socket){
@@ -689,13 +691,18 @@ function startPoolServerTcp(callback){
                                     break;
                                 }
                             }
+                            if (message.indexOf('PROXY TCP4') === 0) {
+				    client_ip[socket.remotePort] = message.split(' ')[2];
+				    log('info', logSystem, 'Proxy V1 request %s: %s', [client_ip[socket.remotePort], message]);
+				    continue;
+                            }
 
                             log('warn', logSystem, 'Malformed message from %s: %s', [socket.remoteAddress, message]);
                             socket.destroy();
 
                             break;
                         }
-                        handleMessage(socket, jsonData, pushMessage);
+                        handleMessage(socket, jsonData, pushMessage, client_ip[socket.remotePort]);
                     }
                     dataBuffer = incomplete;
                 }

--- a/website_example/pages/home.html
+++ b/website_example/pages/home.html
@@ -328,7 +328,7 @@
             var inp2 = parseFloat($('#calcHashRate').val()) * rateUnit;
             var resl = ( lastStats.network.reward / coinUnits) / ((lastStats.network.difficulty / inp2) / 86400  );
             if (!isNaN(resl)) {
-                updateText('calcHashAmount', (Math.round(resl * 100) / 100).toString());
+                updateText('calcHashAmount', (Math.round(resl * 1000) / 1000).toString());
                 return;
             }
         }

--- a/website_example/pages/home.html
+++ b/website_example/pages/home.html
@@ -281,6 +281,8 @@
 
     var intervalMarketPolling = setInterval(updateMarkets, 300000); //poll market data every 5 minutes
     var xhrMarketGets = {};
+    var conversionRate;
+    var conversionUnit;
     updateMarkets();
     function updateMarkets(){
         var completedFetches = 0;
@@ -299,6 +301,11 @@
 
                         if (price > 1) price = Math.round(price * 100) / 100;
                         else price = marketsData[f].ticker.price;
+
+                        if (typeof(cryptonatorEarnings) != 'undefined' && cryptonatorWidget[f] == cryptonatorEarnings) {
+                            conversionRate = parseFloat(price);
+                            conversionUnit = marketsData[f].ticker.target;
+                        }
 
                         $marketHeader.after('<div class="marketTicker">' + marketsData[f].ticker.base + ': <span>' + price + ' ' + marketsData[f].ticker.target + '</span></div>');
                     }
@@ -408,8 +415,18 @@
 
                     updateText('yourHashrateHolder', (data.stats.hashrate || '0 H') + '/sec');
                     updateText('yourHashes', (data.stats.hashes || 0).toString());
-                    updateText('yourPaid', getReadableCoins(data.stats.paid));
-                    updateText('yourPendingBalance', getReadableCoins(data.stats.balance));
+                    var earningsPaid = (data.stats.paid || 0);
+                    var convertedPaid = Math.round(100 * parseFloat(getReadableCoins(earningsPaid,0,false)) * conversionRate) / 100;
+                    var earningsBalance = (data.stats.balance || 0);
+                    var convertedBalance = Math.round(100 * parseFloat(getReadableCoins(earningsBalance,0,false)) * conversionRate) / 100;
+                    if (conversionUnit) {
+                        updateText('yourPaid', getReadableCoins(earningsPaid) + " (" + convertedPaid  + " " + conversionUnit + ")");
+                        updateText('yourPendingBalance', getReadableCoins(earningsBalance) + " (" + convertedBalance  + " " + conversionUnit + ")");
+                    }
+                    else {
+                        updateText('yourPaid', getReadableCoins(earningsPaid));
+                        updateText('yourPendingBalance', getReadableCoins(earningsBalance));
+                    }
 
                     renderPayments(data.payments);
 


### PR DESCRIPTION
Doc: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

The proxy support not only enables miners behind a proxy-v1 to mine in the pool, it also enables the use of a local proxy; for example, to provide a TLS.

The TLS layer can be provided for example by hitch, by setting a local proxy:
`$ hitch --daemon --backend=[127.0.0.1]:5555 --frontend=[*]:5566 pool.pem --write-proxy-v1`

If the `--write-proxy-v1` parameter is not used, the pool service will assume the miner is located in 127.0.0.1, which will break the ip-based ban system and will open the system to atacks.

If the `--write-proxy-v1` parameter was used, the miner failed to connect to the pool because the pool was incapable of parsing the proxy header.

This commit enables the the pool to parse the proxy v1 header and thus to use hitch or a similar process to provide a TLS layer to the pool.

This code has been tested and is being used in https://www.moneropool.us