### PR TITLE
Fix missing miner id

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -320,7 +320,8 @@ Miner.prototype = {
         return {
             blob: blob,
             job_id: newJob.id,
-            target: target
+            target: target,
+            id: this.id
         };
     },
     checkBan: function(validShare){


### PR DESCRIPTION
The miner id is missing in the new job, this is an issue when when there is one connection for several miners (like proxy).