### PR TITLE
Improve performance of redis command queue - #238

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -21,7 +21,7 @@ var redisCommands = [
     ['zcard', config.coin + ':blocks:matured'],
     ['zrevrange', config.coin + ':payments:all', 0, config.api.payments - 1, 'WITHSCORES'],
     ['zcard', config.coin + ':payments:all'],
-    ['keys', config.coin + ':payments:*']
+    ['scan', 'cursor', '0', 'match', config.coin + ':payments:*', 'count', '9999999']
 ];
 
 var currentStats = "";


### PR DESCRIPTION
This PR makes a first step, solving the performance issues adressed in #238 by using the redis [SCAN](https://redis.io/commands/scan) command instead of the KEYS command, which does not block the main queue.

Taken from [redis documentation](https://redis.io/commands/keys)

> Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases. This command is intended for debugging and special operations, such as changing your keyspace layout. Don't use KEYS in your regular application code. 