### PR TITLE
Remove bignum (because it's outdated and a mess)

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -279,7 +279,7 @@ Miner.prototype = {
         var padded = new Buffer(32);
         padded.fill(0);
 
-        var diffBuff = diff1.div(this.difficulty).toBuffer();
+        var diffBuff = diff1.divide(this.difficulty).toBuffer();
         diffBuff.copy(padded, 32 - diffBuff.length);
 
         var buff = padded.slice(0, 4);
@@ -449,7 +449,7 @@ function processShare(miner, job, blockTemplate, nonce, resultHash){
     var hashArray = hash.toJSON();
     hashArray.reverse();
     var hashNum = bignum.fromBuffer(new Buffer(hashArray));
-    var hashDiff = diff1.div(hashNum);
+    var hashDiff = diff1.divide(hashNum);
 
 
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -279,7 +279,7 @@ Miner.prototype = {
         var padded = new Buffer(32);
         padded.fill(0);
 
-        var diffBuff = diff1.divide(this.difficulty).toBuffer();
+        var diffBuff = (diff1 / this.difficulty).toBuffer();
         diffBuff.copy(padded, 32 - diffBuff.length);
 
         var buff = padded.slice(0, 4);
@@ -449,7 +449,7 @@ function processShare(miner, job, blockTemplate, nonce, resultHash){
     var hashArray = hash.toJSON();
     hashArray.reverse();
     var hashNum = bignum.fromBuffer(new Buffer(hashArray));
-    var hashDiff = diff1.divide(hashNum);
+    var hashDiff = diff1 / hashNum;
 
 
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -3,7 +3,6 @@ var net = require('net');
 var crypto = require('crypto');
 
 var async = require('async');
-var bignum = require('bignum');
 var multiHashing = require('multi-hashing');
 var cnUtil = require('cryptonote-util');
 
@@ -28,7 +27,7 @@ function cryptoNightFast(buf) {
     return cryptoNight(Buffer.concat([new Buffer([buf.length]), buf]), true);
 }
 
-var diff1 = bignum('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF', 16);
+var diff1 = BigInt('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF', 16);
 
 var instanceId = crypto.randomBytes(4);
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "url": "https://github.com/zone117x/node-cryptonote-pool.git"
     },
     "dependencies": {
-        "bignum": "0.12.5",
         "async": "1.5.2",
         "redis": "0.12.1",
         "cli-color": "1.1.0",


### PR DESCRIPTION
Removed reference to bignum! This means that we can save ourselves from installing the mess that bignum is!
On a technical level, bignum is **outdated** and the developers want you to use JS's BigInt. The given changes should change it to BigInt.

Since I am not a professional developer, I would kindly ask for people to check my code before merging it in and review issues that may happen. I made sure to check all occurences of the only bignum in the project, `diff1`.